### PR TITLE
Allow to configure SecureBundle ZIP in textual form

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <module>tests</module>
   </modules>
   <properties>
-    <messaging.connectors.commons.version>1.0.9</messaging.connectors.commons.version>
+    <messaging.connectors.commons.version>1.0.10-SNAPSHOT</messaging.connectors.commons.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <module>tests</module>
   </modules>
   <properties>
-    <messaging.connectors.commons.version>1.0.10-SNAPSHOT</messaging.connectors.commons.version>
+    <messaging.connectors.commons.version>1.0.10</messaging.connectors.commons.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>

--- a/pulsar-impl/pom.xml
+++ b/pulsar-impl/pom.xml
@@ -191,7 +191,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
                 </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <relocations>
                 <relocation>

--- a/pulsar-impl/src/it/java/com/datastax/oss/pulsar/sink/cloud/CloudSniEndToEndIT.java
+++ b/pulsar-impl/src/it/java/com/datastax/oss/pulsar/sink/cloud/CloudSniEndToEndIT.java
@@ -45,6 +45,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.time.Duration;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
@@ -167,6 +168,19 @@ public class CloudSniEndToEndIT extends ITConnectorBase {
     performInsert(
         DefaultConsistencyLevel.LOCAL_QUORUM,
         parametersWithSecureBundle(configFile.toExternalForm()));
+
+    // then
+    assertThat(logs.getLoggedMessages())
+        .doesNotContain("Cloud deployments reject consistency level");
+  }
+
+  @Test
+  void should_insert_using_base64_encoded_secure_bundle() throws IOException {
+    byte[] secureBundle = Files.readAllBytes(proxy.getSecureBundlePath());
+    String encoded = "base64:" + Base64.getEncoder().encodeToString(secureBundle);
+
+    // when
+    performInsert(DefaultConsistencyLevel.LOCAL_QUORUM, parametersWithSecureBundle(encoded));
 
     // then
     assertThat(logs.getLoggedMessages())


### PR DESCRIPTION
- allow users to encode the ZIP file using standard base64 linux tool
- This is the new setting cloud.secureConnectBundle=base64:XXXXXXXXX

With this change it is easier to connect to Astra and to secure Cassandra clusters without the need to deploy the ZIP file.
Deploying the ZIP file is very awkward on K8S and in Pulsar IO framework