### PR TITLE
Fix ClassCastException while sending null values for GenericRecord fields

### DIFF
--- a/pulsar-impl/pom.xml
+++ b/pulsar-impl/pom.xml
@@ -191,7 +191,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
                 </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <relocations>
                 <relocation>

--- a/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/CassandraSinkTask.java
+++ b/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/CassandraSinkTask.java
@@ -87,8 +87,8 @@ public class CassandraSinkTask<T> implements Sink<T> {
             } else {
               log.warn("Error decoding/mapping Pulsar record {}: {}", impl, e.getMessage());
             }
-            if (log.isDebugEnabled()) {
-              log.debug("Details of the error", e);
+            if (verbose) {
+              log.warn("Details of the error", e);
             }
             if (!ignore) {
               if (verbose) {

--- a/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/LocalSchemaRegistry.java
+++ b/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/LocalSchemaRegistry.java
@@ -57,9 +57,10 @@ public class LocalSchemaRegistry {
       if (res == null) {
         res = PulsarSchema.createFromStruct(path, struct, this);
         registry.put(path, res);
+      } else {
+        // need to recover nulls from previous records
+        res.update(path, struct, this);
       }
-      // need to recover nulls from previous records
-      res.update(path, struct, this);
       return res;
     } else {
       // primitive values

--- a/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/PulsarSchema.java
+++ b/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/PulsarSchema.java
@@ -169,7 +169,14 @@ public class PulsarSchema implements AbstractSchema {
 
   @Override
   public String toString() {
-    return "PulsarSchema{" + "fields=" + fields + ", type=" + type + '}';
+    return "PulsarSchema{"
+        + "fields="
+        + fields
+        + ", type="
+        + type
+        + ", valueWasNull="
+        + valueWasNull
+        + '}';
   }
 
   public boolean isValueWasNull() {

--- a/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/PulsarSchema.java
+++ b/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/PulsarSchema.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Datatype. */
 public class PulsarSchema implements AbstractSchema {
@@ -37,12 +39,13 @@ public class PulsarSchema implements AbstractSchema {
   public static final PulsarSchema BOOLEAN = new PulsarSchema(AbstractSchema.Type.BOOLEAN);
   public static final PulsarSchema STRING = new PulsarSchema(AbstractSchema.Type.STRING);
   public static final PulsarSchema BYTES = new PulsarSchema(AbstractSchema.Type.BYTES);
+  public static final PulsarSchema FIRST_VALUE_NULL = new PulsarSchema(Type.STRING, false);
 
   public static PulsarSchema of(String path, Object value, LocalSchemaRegistry registry) {
     if (value == null) {
       // there is no support for NULLS in Cassandra Driver type system
       // using STRING
-      return STRING;
+      return FIRST_VALUE_NULL;
     }
     if (value instanceof Integer) {
       return INT32;
@@ -88,17 +91,26 @@ public class PulsarSchema implements AbstractSchema {
 
   private final Map<String, PulsarField> fields;
   private final AbstractSchema.Type type;
+  private final boolean valueWasNull;
 
   private PulsarSchema(String path, GenericRecord template, LocalSchemaRegistry registry) {
     this.fields = new ConcurrentHashMap<>();
     this.type = AbstractSchema.Type.STRUCT;
+    this.valueWasNull = true;
     update(path, template, registry);
   }
 
   private PulsarSchema(AbstractSchema.Type type) {
+    this(type, true);
+  }
+
+  private PulsarSchema(AbstractSchema.Type type, boolean valueWasNull) {
     this.type = type;
     this.fields = Collections.emptyMap();
+    this.valueWasNull = valueWasNull;
   }
+
+  private static final Logger log = LoggerFactory.getLogger(PulsarSchema.class);
 
   /**
    * Unfortunately Pulsar does not return information about the datatype of Fields, so we have to
@@ -117,6 +129,13 @@ public class PulsarSchema implements AbstractSchema {
       // it is not expected that a field changes data type
       // once we find a non-null value
       PulsarSchema schemaForField = PulsarSchema.of(path + "." + f.getName(), value, registry);
+
+      if (fields.containsKey(f.getName()) && !schemaForField.isValueWasNull()) {
+        if (log.isDebugEnabled()) {
+          log.debug("skipping updating field {} schema because it was a NULL value");
+        }
+        continue;
+      }
       PulsarField field = new PulsarField(f.getName(), schemaForField);
       this.fields.put(f.getName(), field);
     }
@@ -151,5 +170,9 @@ public class PulsarSchema implements AbstractSchema {
   @Override
   public String toString() {
     return "PulsarSchema{" + "fields=" + fields + ", type=" + type + '}';
+  }
+
+  public boolean isValueWasNull() {
+    return valueWasNull;
   }
 }

--- a/pulsar-impl/src/test/java/com/datastax/oss/sink/pulsar/PulsarSchemaTest.java
+++ b/pulsar-impl/src/test/java/com/datastax/oss/sink/pulsar/PulsarSchemaTest.java
@@ -45,7 +45,7 @@ public class PulsarSchemaTest {
 
     assertSame(PulsarSchema.BYTES, PulsarSchema.of("the-path", new byte[0], registry));
 
-    assertSame(PulsarSchema.STRING, PulsarSchema.of("the-path", null, registry));
+    assertSame(PulsarSchema.FIRST_VALUE_NULL, PulsarSchema.of("the-path", null, registry));
   }
 
   @Test
@@ -61,7 +61,7 @@ public class PulsarSchemaTest {
     assertEquals(2, schema.fields().size());
     assertSame(PulsarSchema.INT32, schema.field("test").schema());
     // let's assume it is a STRING
-    assertSame(PulsarSchema.STRING, schema.field("nullvalue").schema());
+    assertSame(PulsarSchema.FIRST_VALUE_NULL, schema.field("nullvalue").schema());
 
     // then we get to know that it is a "double"
     GenericRecordImpl genericRecordNotNull =

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/KeyValueAvroTest.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/KeyValueAvroTest.java
@@ -19,7 +19,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.datastax.oss.dsbulk.tests.ccm.CCMCluster;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.api.Producer;
@@ -32,7 +34,7 @@ import org.awaitility.Awaitility;
 /** Use KeyVlue(AVRO,AVRO) like in a CDC data flow */
 public class KeyValueAvroTest extends PulsarCCMTestBase {
 
-  private static final String MAPPING = "a=key.fieldKey, b=value.field1";
+  private static final String MAPPING = "a=key.fieldKey, b=value.field1, c=value.longField";
 
   public KeyValueAvroTest(CCMCluster ccm, CqlSession session) throws Exception {
     super(ccm, session, MAPPING);
@@ -40,6 +42,9 @@ public class KeyValueAvroTest extends PulsarCCMTestBase {
 
   @Override
   protected void performTest(final PulsarSinkTester pulsarSink) throws PulsarClientException {
+    Long long1 = Instant.now().toEpochMilli();
+    Long long2 = Instant.now().toEpochMilli() + 1000L;
+
     // please note that we are setting the Schema AFTER the creation of the Sink
     try (Producer<KeyValue<MyKey, MyBean>> producer =
         pulsarSink
@@ -51,7 +56,19 @@ public class KeyValueAvroTest extends PulsarCCMTestBase {
                     KeyValueEncodingType.SEPARATED))
             .topic(pulsarSink.getTopic())
             .create()) {
-      producer.newMessage().value(new KeyValue<>(new MyKey(838), new MyBean("value1"))).send();
+
+      producer
+          .newMessage()
+          .value(new KeyValue<>(new MyKey(838), new MyBean("value1", long1)))
+          .send();
+      producer
+          .newMessage()
+          .value(new KeyValue<>(new MyKey(838), new MyBean("value1", null)))
+          .send();
+      producer
+          .newMessage()
+          .value(new KeyValue<>(new MyKey(838), new MyBean("value1", long2)))
+          .send();
     }
     try {
       Awaitility.waitAtMost(2, TimeUnit.MINUTES)
@@ -65,8 +82,10 @@ public class KeyValueAvroTest extends PulsarCCMTestBase {
       List<Row> results = session.execute("SELECT * FROM table1").all();
       for (Row row : results) {
         log.info("ROW: " + row);
+        System.out.println("get c value: " + row.getObject("c"));
         assertEquals(838, row.getInt("a"));
         assertEquals("value1", row.getString("b"));
+        assertEquals(long2, row.get("c", TypeCodecs.TIMESTAMP).toEpochMilli());
       }
       assertEquals(1, results.size());
     } finally {

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/KeyValueAvroTest.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/KeyValueAvroTest.java
@@ -41,6 +41,12 @@ public class KeyValueAvroTest extends PulsarCCMTestBase {
   }
 
   @Override
+  protected void preparePulsarSinkTester(PulsarSinkTester pulsarSink) {
+    super.preparePulsarSinkTester(pulsarSink);
+    connectorProperties.put("batchSize", "2");
+  }
+
+  @Override
   protected void performTest(final PulsarSinkTester pulsarSink) throws PulsarClientException {
     Long long1 = Instant.now().toEpochMilli();
     Long long2 = Instant.now().toEpochMilli() + 1000L;
@@ -60,6 +66,10 @@ public class KeyValueAvroTest extends PulsarCCMTestBase {
       producer
           .newMessage()
           .value(new KeyValue<>(new MyKey(838), new MyBean("value1", long1)))
+          .send();
+      producer
+          .newMessage()
+          .value(new KeyValue<>(new MyKey(838), new MyBean("value1", null)))
           .send();
       producer
           .newMessage()

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/PulsarCCMTestBase.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/PulsarCCMTestBase.java
@@ -61,7 +61,9 @@ abstract class PulsarCCMTestBase {
 
     session.execute(
         SimpleStatement.builder(
-                "CREATE TABLE IF NOT EXISTS table1 (" + "a int PRIMARY KEY, " + "b varchar)")
+                "CREATE TABLE IF NOT EXISTS table1 ("
+                    + "a int PRIMARY KEY, "
+                    + "b varchar, c TIMESTAMP)")
             .setTimeout(Duration.ofSeconds(10))
             .build());
 
@@ -116,9 +118,15 @@ abstract class PulsarCCMTestBase {
   public static final class MyBean {
 
     private String field1;
+    private Long longField;
 
     public MyBean(String field1) {
       this.field1 = field1;
+    }
+
+    public MyBean(String field1, Long longField) {
+      this.field1 = field1;
+      this.longField = longField;
     }
 
     public String getField1() {
@@ -127,6 +135,14 @@ abstract class PulsarCCMTestBase {
 
     public void setField1(String field1) {
       this.field1 = field1;
+    }
+
+    public Long getLongField() {
+      return longField;
+    }
+
+    public void setLongField(Long longField) {
+      this.longField = longField;
     }
   }
 }


### PR DESCRIPTION
When the first sent value for a GenericRecord is null, the registry saves the schema for the field as String. Since the value is null there is no issue. When a new value (filled) arrives, the registry is overriden and then the new schema is used correctly and the correct Cassandra codec is used. If another null value arrives for the same field, the schema registry is overridden with the String fake schema.

The processing is done in "batch" and the registry take the latest schema for the field (may be String in case of null). Then  it process the first value (which may be filled) and throws this error
```
java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.String (java.lang.Long and java.lang.String are in module java.base of loader ‘bootstrap’)
        at com.datastax.oss.dsbulk.codecs.text.string.StringToInstantCodec.externalToInternal(StringToInstantCodec.java:27) ~[dsbulk-codecs-text-1.6.0.jar:?]
        at com.datastax.oss.dsbulk.codecs.api.ConvertingCodec.encode(ConvertingCodec.java:70) ~[dsbulk-codecs-api-1.6.0.jar:?]
        at com.datastax.oss.common.sink.RecordMapper.bindColumn(RecordMapper.java:299) ~[cassandra-sink-pulsar-1.6.1.jar:?]
        at com.datastax.oss.common.sink.RecordMapper.bindColumnsToBuilder(RecordMapper.java:203) ~[cassandra-sink-pulsar-1.6.1.jar:?]
        at com.datastax.oss.common.sink.RecordMapper.map(RecordMapper.java:122) ~[cassandra-sink-pulsar-1.6.1.jar:?]
        at com.datastax.oss.common.sink.AbstractSinkTask.mapAndQueueRecord(AbstractSinkTask.java:211) ~[cassandra-sink-pulsar-1.6.1.jar:?]
        at com.datastax.oss.common.sink.AbstractSinkTask.lambda$put$1(AbstractSinkTask.java:108) ~[cassandra-sink-pulsar-1.6.1.jar:?]
        at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1736) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
```

The fix is to no override the schema registry value with the fake String schema if a schema is already there