### PR TITLE
Add PulsarStuct to JsonNode codec adapter

### DIFF
--- a/pulsar-impl/src/main/java/com/datastax/oss/pulsar/sink/codecs/PulsarCodecProvider.java
+++ b/pulsar-impl/src/main/java/com/datastax/oss/pulsar/sink/codecs/PulsarCodecProvider.java
@@ -41,8 +41,9 @@ public class PulsarCodecProvider implements ConvertingCodecProvider {
             || externalJavaType.equals(GenericType.of(AbstractStruct.class)))) {
       return Optional.of(new StructToUDTCodec(codecFactory, (UserDefinedType) cqlType));
     }
-    // TODO: Generalize this part to handle Avro as well
-    // TODO: Check the behavior of the above if condition if the PulsarStruct wraps a native object.
+
+    // TODO: Add complex cql types support for Avro:
+    // https://github.com/datastax/pulsar-sink/issues/33
     if (externalJavaType.equals(GenericType.of(PulsarStruct.class))
         || externalJavaType.equals(GenericType.of(AbstractStruct.class))) {
       return Optional.of(new StructToJsonNodeCodecAdapter(codecFactory, cqlType));

--- a/pulsar-impl/src/main/java/com/datastax/oss/pulsar/sink/codecs/PulsarCodecProvider.java
+++ b/pulsar-impl/src/main/java/com/datastax/oss/pulsar/sink/codecs/PulsarCodecProvider.java
@@ -41,6 +41,12 @@ public class PulsarCodecProvider implements ConvertingCodecProvider {
             || externalJavaType.equals(GenericType.of(AbstractStruct.class)))) {
       return Optional.of(new StructToUDTCodec(codecFactory, (UserDefinedType) cqlType));
     }
+    // TODO: Generalize this part to handle Avro as well
+    // TODO: Check the behavior of the above if condition if the PulsarStruct wraps a native object.
+    if (externalJavaType.equals(GenericType.of(PulsarStruct.class))
+        || externalJavaType.equals(GenericType.of(AbstractStruct.class))) {
+      return Optional.of(new StructToJsonNodeCodecAdapter(codecFactory, cqlType));
+    }
     return Optional.empty();
   }
 }

--- a/pulsar-impl/src/main/java/com/datastax/oss/pulsar/sink/codecs/StructToJsonNodeCodecAdapter.java
+++ b/pulsar-impl/src/main/java/com/datastax/oss/pulsar/sink/codecs/StructToJsonNodeCodecAdapter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.sink.codecs;
+
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import com.datastax.oss.dsbulk.codecs.api.ConvertingCodec;
+import com.datastax.oss.dsbulk.codecs.api.ConvertingCodecFactory;
+import com.datastax.oss.dsbulk.codecs.text.json.JsonNodeConvertingCodec;
+import com.datastax.oss.sink.pulsar.PulsarStruct;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.*;
+
+/**
+ * A generic codec adapter to convert a Pulsar Struct wrapping JSON objets to any sql type. It
+ * leverages the {@link JsonNodeConvertingCodec} and all its derivatives.
+ */
+public class StructToJsonNodeCodecAdapter<T> extends ConvertingCodec<PulsarStruct, T> {
+
+  private final ConvertingCodecFactory codecFactory;
+  private final DataType definition;
+
+  private ConvertingCodec<JsonNode, T> jsonNodeCodec;
+
+  StructToJsonNodeCodecAdapter(ConvertingCodecFactory codecFactory, DataType cqlType) {
+    super(codecFactory.getCodecRegistry().codecFor(cqlType), PulsarStruct.class);
+    this.codecFactory = codecFactory;
+    this.definition = cqlType;
+    this.jsonNodeCodec =
+        codecFactory.createConvertingCodec(this.definition, GenericType.of(JsonNode.class), true);
+  }
+
+  @Override
+  public T externalToInternal(PulsarStruct external) {
+    if (external == null) {
+      return null;
+    } else if (external.getRecord().getNativeObject() instanceof JsonNode) {
+      return this.jsonNodeCodec.externalToInternal(
+          (JsonNode) external.getRecord().getNativeObject());
+    }
+
+    return null;
+  }
+
+  @Override
+  public PulsarStruct internalToExternal(T dt) {
+    if (dt == null) {
+      return null;
+    }
+    throw new UnsupportedOperationException(
+        "This codec does not support converting from JsonNode to cql types");
+  }
+}

--- a/pulsar-impl/src/main/java/com/datastax/oss/pulsar/sink/codecs/StructToJsonNodeCodecAdapter.java
+++ b/pulsar-impl/src/main/java/com/datastax/oss/pulsar/sink/codecs/StructToJsonNodeCodecAdapter.java
@@ -52,15 +52,15 @@ public class StructToJsonNodeCodecAdapter<T> extends ConvertingCodec<PulsarStruc
           (JsonNode) external.getRecord().getNativeObject());
     }
 
-    return null;
+    Object nativeObject = external.getRecord().getNativeObject();
+    throw new IllegalArgumentException(
+        "Expecting JsonNode, got "
+            + (nativeObject == null ? "NULL" : nativeObject.getClass().getName()));
   }
 
   @Override
-  public PulsarStruct internalToExternal(T dt) {
-    if (dt == null) {
-      return null;
-    }
+  public PulsarStruct internalToExternal(T internal) {
     throw new UnsupportedOperationException(
-        "This codec does not support converting from JsonNode to cql types");
+        "This codec does not support converting to PulsarStruct");
   }
 }

--- a/pulsar-impl/src/test/java/com/datastax/oss/pulsar/sink/codecs/StructToJsonNodeCodecAdapterTest.java
+++ b/pulsar-impl/src/test/java/com/datastax/oss/pulsar/sink/codecs/StructToJsonNodeCodecAdapterTest.java
@@ -54,7 +54,7 @@ class StructToJsonNodeCodecAdapterTest {
               .<PulsarStruct, Map<String, String>>createConvertingCodec(
                   mapType, GenericType.of(PulsarStruct.class), true);
 
-  private final StructToJsonNodeCodecAdapter structArrayCodec =
+  private final StructToJsonNodeCodecAdapter structListCodec =
       (StructToJsonNodeCodecAdapter)
           new ConvertingCodecFactory(new TextConversionContext())
               .<PulsarStruct, List<String>>createConvertingCodec(
@@ -82,12 +82,12 @@ class StructToJsonNodeCodecAdapterTest {
   }
 
   @Test
-  void should_convert_array_from_valid_external() {
+  void should_convert_list_from_valid_external() {
     JsonNode nativeObject = mapper.valueToTree(listValue);
     struct = new GenericRecordImpl(nativeObject);
     record = new PulsarRecordImpl(null, null, struct, schema);
 
-    assertThat(structArrayCodec)
+    assertThat(structListCodec)
         .convertsFromExternal(PulsarStruct.ofRecord(record, registry))
         .toInternal(listValue)
         .convertsFromExternal(null)
@@ -102,7 +102,61 @@ class StructToJsonNodeCodecAdapterTest {
 
   @Test
   void should_not_convert_list_from_invalid_external() throws Exception {
-    assertThat(structArrayCodec)
+    assertThat(structListCodec)
         .cannotConvertFromExternal(mapper.readTree("[\"not a pulsar struct!\"]"));
+  }
+
+  @Test
+  void should_not_convert_list_from_null_internal() {
+    assertThat(structListCodec).cannotConvertFromInternal(null);
+  }
+
+  @Test
+  void should_not_convert_map_from_null_internal() {
+    assertThat(structMapCodec).cannotConvertFromInternal(null);
+  }
+
+  @Test
+  void should_not_convert_list_from_internal() {
+    assertThat(structMapCodec).cannotConvertFromInternal(listValue);
+  }
+
+  @Test
+  void should_not_convert_map_from_internal() {
+    assertThat(structMapCodec).cannotConvertFromInternal(mapValue);
+  }
+
+  @Test
+  void should_not_convert_list_from_null_native_external() {
+    struct = new GenericRecordImpl(null);
+    record = new PulsarRecordImpl(null, null, struct, schema);
+
+    assertThat(structListCodec).cannotConvertFromExternal(PulsarStruct.ofRecord(record, registry));
+  }
+
+  @Test
+  void should_not_convert_map_from_null_native_external() {
+    struct = new GenericRecordImpl(null);
+    record = new PulsarRecordImpl(null, null, struct, schema);
+
+    assertThat(structMapCodec).cannotConvertFromExternal(PulsarStruct.ofRecord(record, registry));
+  }
+
+  @Test
+  void should_not_convert_list_from_invalid_native_external() {
+    Long nativeObject = 0L;
+    struct = new GenericRecordImpl(nativeObject);
+    record = new PulsarRecordImpl(null, null, struct, schema);
+
+    assertThat(structListCodec).cannotConvertFromExternal(PulsarStruct.ofRecord(record, registry));
+  }
+
+  @Test
+  void should_not_convert_map_from_invalid_native_external() {
+    Long nativeObject = 0L;
+    struct = new GenericRecordImpl(nativeObject);
+    record = new PulsarRecordImpl(null, null, struct, schema);
+
+    assertThat(structMapCodec).cannotConvertFromExternal(PulsarStruct.ofRecord(record, registry));
   }
 }

--- a/pulsar-impl/src/test/java/com/datastax/oss/pulsar/sink/codecs/StructToJsonNodeCodecAdapterTest.java
+++ b/pulsar-impl/src/test/java/com/datastax/oss/pulsar/sink/codecs/StructToJsonNodeCodecAdapterTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.sink.codecs;
+
+import static com.datastax.oss.dsbulk.tests.assertions.TestAssertions.assertThat;
+
+import com.datastax.oss.driver.api.core.type.*;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import com.datastax.oss.driver.internal.core.type.DefaultListType;
+import com.datastax.oss.driver.internal.core.type.DefaultMapType;
+import com.datastax.oss.driver.internal.core.type.PrimitiveType;
+import com.datastax.oss.dsbulk.codecs.api.ConvertingCodecFactory;
+import com.datastax.oss.dsbulk.codecs.text.TextConversionContext;
+import com.datastax.oss.sink.pulsar.GenericRecordImpl;
+import com.datastax.oss.sink.pulsar.LocalSchemaRegistry;
+import com.datastax.oss.sink.pulsar.PulsarRecordImpl;
+import com.datastax.oss.sink.pulsar.PulsarStruct;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.functions.api.Record;
+import org.junit.jupiter.api.Test;
+
+class StructToJsonNodeCodecAdapterTest {
+  private final PrimitiveType textPrimitiveType = new PrimitiveType(13);
+  private final MapType mapType = new DefaultMapType(textPrimitiveType, textPrimitiveType, false);
+
+  private final ListType listType = new DefaultListType(textPrimitiveType, false);
+
+  private final Map<String, String> mapValue = ImmutableMap.of("k1", "v1", "k2", "v2");
+
+  private final List<String> listValue = ImmutableList.of("l1", "l2");
+  private final StructToJsonNodeCodecAdapter structMapCodec =
+      (StructToJsonNodeCodecAdapter)
+          new ConvertingCodecFactory(new TextConversionContext())
+              .<PulsarStruct, Map<String, String>>createConvertingCodec(
+                  mapType, GenericType.of(PulsarStruct.class), true);
+
+  private final StructToJsonNodeCodecAdapter structArrayCodec =
+      (StructToJsonNodeCodecAdapter)
+          new ConvertingCodecFactory(new TextConversionContext())
+              .<PulsarStruct, List<String>>createConvertingCodec(
+                  listType, GenericType.of(PulsarStruct.class), true);
+
+  private Schema schema;
+  private Record<GenericRecord> record;
+  private GenericRecordImpl struct;
+
+  private ObjectMapper mapper = new ObjectMapper();
+
+  private final LocalSchemaRegistry registry = new LocalSchemaRegistry();
+
+  @Test
+  void should_convert_map_from_valid_external() {
+    JsonNode nativeObject = mapper.valueToTree(mapValue);
+    struct = new GenericRecordImpl(nativeObject);
+    record = new PulsarRecordImpl(null, null, struct, schema);
+
+    assertThat(structMapCodec)
+        .convertsFromExternal(PulsarStruct.ofRecord(record, registry))
+        .toInternal(mapValue)
+        .convertsFromExternal(null)
+        .toInternal(null);
+  }
+
+  @Test
+  void should_convert_array_from_valid_external() {
+    JsonNode nativeObject = mapper.valueToTree(listValue);
+    struct = new GenericRecordImpl(nativeObject);
+    record = new PulsarRecordImpl(null, null, struct, schema);
+
+    assertThat(structArrayCodec)
+        .convertsFromExternal(PulsarStruct.ofRecord(record, registry))
+        .toInternal(listValue)
+        .convertsFromExternal(null)
+        .toInternal(null);
+  }
+
+  @Test
+  void should_not_convert_map_from_invalid_external() throws Exception {
+    assertThat(structMapCodec)
+        .cannotConvertFromExternal(mapper.readTree("{\"not a pulsar struct!\":\"foo\"}"));
+  }
+
+  @Test
+  void should_not_convert_list_from_invalid_external() throws Exception {
+    assertThat(structArrayCodec)
+        .cannotConvertFromExternal(mapper.readTree("[\"not a pulsar struct!\"]"));
+  }
+}

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/JSONFromByteArrayTest.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/JSONFromByteArrayTest.java
@@ -23,6 +23,9 @@ import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.dsbulk.tests.ccm.CCMCluster;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.awaitility.Awaitility;
@@ -49,7 +52,7 @@ public class JSONFromByteArrayTest extends PulsarCCMTestBase {
             .newProducer() // no schema
             .topic(pulsarSink.getTopic())
             .create()) {
-      producer.newMessage().key("838").value("{\"field1\":\"value1\"}".getBytes(UTF_8)).send();
+      producer.newMessage().key("838").value("{\"field1\":\"value1\",\"mapField\":{\"k1\":\"v1\",\"k2\":\"v2\"},\"listField\":[\"l1\",\"l2\"]}".getBytes(UTF_8)).send();
     }
     try {
       Awaitility.waitAtMost(1, TimeUnit.MINUTES)
@@ -65,6 +68,8 @@ public class JSONFromByteArrayTest extends PulsarCCMTestBase {
         log.info("ROW: " + row);
         assertEquals(838, row.getInt("a"));
         assertEquals("value1", row.getString("b"));
+        assertEquals(ImmutableMap.of("k1", "v1", "k2", "v2"), row.getMap("d", String.class, String.class));
+        assertEquals(ImmutableList.of("l1", "l2"), row.getList("e", String.class));
       }
       assertEquals(1, results.size());
     } finally {

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/JSONFromByteArrayTest.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/JSONFromByteArrayTest.java
@@ -20,12 +20,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.internal.core.data.DefaultUdtValue;
 import com.datastax.oss.dsbulk.tests.ccm.CCMCluster;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.awaitility.Awaitility;
@@ -52,7 +52,11 @@ public class JSONFromByteArrayTest extends PulsarCCMTestBase {
             .newProducer() // no schema
             .topic(pulsarSink.getTopic())
             .create()) {
-      producer.newMessage().key("838").value("{\"field1\":\"value1\",\"mapField\":{\"k1\":\"v1\",\"k2\":\"v2\"},\"listField\":[\"l1\",\"l2\"]}".getBytes(UTF_8)).send();
+      producer
+          .newMessage()
+          .key("838")
+          .value("{\"field1\":\"value1\",\"mapField\":{\"k1\":\"v1\",\"k2\":\"v2\"},\"listField\":[\"l1\",\"l2\"],\"udtField\":{\"f1\":99,\"f2\":\"random\"}}".getBytes(UTF_8))
+          .send();
     }
     try {
       Awaitility.waitAtMost(1, TimeUnit.MINUTES)
@@ -70,6 +74,10 @@ public class JSONFromByteArrayTest extends PulsarCCMTestBase {
         assertEquals("value1", row.getString("b"));
         assertEquals(ImmutableMap.of("k1", "v1", "k2", "v2"), row.getMap("d", String.class, String.class));
         assertEquals(ImmutableList.of("l1", "l2"), row.getList("e", String.class));
+        DefaultUdtValue value = (DefaultUdtValue) row.getUdtValue("f");
+        assertEquals(value.size(), 2);
+        assertEquals(99, value.getInt("f1"));
+        assertEquals("random", value.getString("f2"));
       }
       assertEquals(1, results.size());
     } finally {

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/JSONFromStringWithLegacyStringTaskTest.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/JSONFromStringWithLegacyStringTaskTest.java
@@ -22,6 +22,9 @@ import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.dsbulk.tests.ccm.CCMCluster;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -50,7 +53,7 @@ public class JSONFromStringWithLegacyStringTaskTest extends PulsarCCMTestBase {
             .newProducer(Schema.STRING)
             .topic(pulsarSink.getTopic())
             .create()) {
-      producer.newMessage().key("838").value("{\"field1\":\"value1\"}").send();
+      producer.newMessage().key("838").value("{\"field1\":\"value1\",\"mapField\":{\"k1\":\"v1\",\"k2\":\"v2\"},\"listField\":[\"l1\",\"l2\"]}").send();
     }
     try {
       Awaitility.waitAtMost(1, TimeUnit.MINUTES)
@@ -66,6 +69,8 @@ public class JSONFromStringWithLegacyStringTaskTest extends PulsarCCMTestBase {
         log.info("ROW: " + row);
         assertEquals(838, row.getInt("a"));
         assertEquals("value1", row.getString("b"));
+        assertEquals(ImmutableMap.of("k1", "v1", "k2", "v2"), row.getMap("d", String.class, String.class));
+        assertEquals(ImmutableList.of("l1", "l2"), row.getList("e", String.class));
       }
       assertEquals(1, results.size());
     } finally {

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/JSONFromStringWithLegacyStringTaskTest.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/JSONFromStringWithLegacyStringTaskTest.java
@@ -19,12 +19,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.internal.core.data.DefaultUdtValue;
 import com.datastax.oss.dsbulk.tests.ccm.CCMCluster;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -53,7 +53,11 @@ public class JSONFromStringWithLegacyStringTaskTest extends PulsarCCMTestBase {
             .newProducer(Schema.STRING)
             .topic(pulsarSink.getTopic())
             .create()) {
-      producer.newMessage().key("838").value("{\"field1\":\"value1\",\"mapField\":{\"k1\":\"v1\",\"k2\":\"v2\"},\"listField\":[\"l1\",\"l2\"]}").send();
+      producer
+          .newMessage()
+          .key("838")
+          .value("{\"field1\":\"value1\",\"mapField\":{\"k1\":\"v1\",\"k2\":\"v2\"},\"listField\":[\"l1\",\"l2\"],\"udtField\":{\"f1\":99,\"f2\":\"random\"}}")
+          .send();
     }
     try {
       Awaitility.waitAtMost(1, TimeUnit.MINUTES)
@@ -71,6 +75,10 @@ public class JSONFromStringWithLegacyStringTaskTest extends PulsarCCMTestBase {
         assertEquals("value1", row.getString("b"));
         assertEquals(ImmutableMap.of("k1", "v1", "k2", "v2"), row.getMap("d", String.class, String.class));
         assertEquals(ImmutableList.of("l1", "l2"), row.getList("e", String.class));
+        DefaultUdtValue value = (DefaultUdtValue) row.getUdtValue("f");
+        assertEquals(value.size(), 2);
+        assertEquals(99, value.getInt("f1"));
+        assertEquals("random", value.getString("f2"));
       }
       assertEquals(1, results.size());
     } finally {

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/JSONTest.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/JSONTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.internal.core.data.DefaultUdtValue;
 import com.datastax.oss.dsbulk.tests.ccm.CCMCluster;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -36,6 +37,8 @@ public class JSONTest extends PulsarCCMTestBase {
   private final Map<String, String> map = ImmutableMap.of("k1", "v1", "k2", "v2");
   private final List<String> list = ImmutableList.of("l1", "l2");
 
+  private final Map<String, Object> udt = ImmutableMap.of("f1", 99, "f2", "random");
+
   public JSONTest(CCMCluster ccm, CqlSession session) throws Exception {
     super(ccm, session);
   }
@@ -50,7 +53,7 @@ public class JSONTest extends PulsarCCMTestBase {
             .topic(pulsarSink.getTopic())
             .create()) {
 
-      producer.newMessage().key("838").value(new MyBean("value1", map, list)).send();
+      producer.newMessage().key("838").value(new MyBean("value1", map, list, udt)).send();
     }
     try {
       Awaitility.waitAtMost(1, TimeUnit.MINUTES)
@@ -68,6 +71,10 @@ public class JSONTest extends PulsarCCMTestBase {
         assertEquals("value1", row.getString("b"));
         assertEquals(map, row.getMap("d", String.class, String.class));
         assertEquals(list, row.getList("e", String.class));
+        DefaultUdtValue value = (DefaultUdtValue) row.getUdtValue("f");
+        assertEquals(value.size(), 2);
+        assertEquals(udt.get("f1"), value.getInt("f1"));
+        assertEquals(udt.get("f2"), value.getString("f2"));
       }
       assertEquals(1, results.size());
     } finally {

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/PulsarCCMTestBase.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/PulsarCCMTestBase.java
@@ -74,7 +74,7 @@ abstract class PulsarCCMTestBase {
                     + "c TIMESTAMP, "
                     + "d map<text,text>, "
                     + "e list<text>, "
-                    + "f udt)")
+                    + "f FROZEN<udt>)") // Non-frozen User-Defined types are not supported in Cassandra 3.0
             .setTimeout(Duration.ofSeconds(10))
             .build());
 

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/PulsarCCMTestBase.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/PulsarCCMTestBase.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.dsbulk.tests.ccm.CCMCluster;
 import com.datastax.oss.dsbulk.tests.ccm.CCMExtension;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -43,7 +44,8 @@ abstract class PulsarCCMTestBase {
   protected final CqlSession session;
   private final String keyspaceName;
 
-  private static final String DEFAULT_MAPPING = "a=key, b=value.field1";
+  private static final String DEFAULT_MAPPING =
+      "a=key, b=value.field1, d=value.mapField, e=value.listField";
 
   @SuppressWarnings("unused")
   PulsarCCMTestBase(CCMCluster ccm, CqlSession session) throws Exception {
@@ -63,7 +65,10 @@ abstract class PulsarCCMTestBase {
         SimpleStatement.builder(
                 "CREATE TABLE IF NOT EXISTS table1 ("
                     + "a int PRIMARY KEY, "
-                    + "b varchar, c TIMESTAMP)")
+                    + "b varchar, "
+                    + "c TIMESTAMP, "
+                    + "d map<text,text>, "
+                    + "e list<text>)")
             .setTimeout(Duration.ofSeconds(10))
             .build());
 
@@ -119,6 +124,8 @@ abstract class PulsarCCMTestBase {
 
     private String field1;
     private Long longField;
+    private Map<String, String> mapField;
+    private List<String> listField;
 
     public MyBean(String field1) {
       this.field1 = field1;
@@ -129,12 +136,34 @@ abstract class PulsarCCMTestBase {
       this.longField = longField;
     }
 
+    public MyBean(String field1, Map<String, String> field2, List<String> field3) {
+      this(field1, Instant.now().toEpochMilli());
+      this.mapField = field2;
+      this.listField = field3;
+    }
+
     public String getField1() {
       return field1;
     }
 
     public void setField1(String field1) {
       this.field1 = field1;
+    }
+
+    public Map<String, String> getMapField() {
+      return mapField;
+    }
+
+    public void setMapField(Map<String, String> mapField) {
+      this.mapField = mapField;
+    }
+
+    public List<String> getListField() {
+      return listField;
+    }
+
+    public void setListField(List<String> listField) {
+      this.listField = listField;
     }
 
     public Long getLongField() {


### PR DESCRIPTION
This change adds codecs to enable Pulsar Structs (wrapping Json schema records) to CQL type conversions. It leverages the exiting Json codes defined [here](https://github.com/datastax/pulsar-sink/issues/30) to spare writing new code. The idea is to unblock users who sends POJOs with Maps to pulsar with C* sink ([Sending Pojo with Map to Sink gives Codec Missing Warning](https://github.com/datastax/pulsar-sink/issues/30)).

Few notes:
* Avro schemas to complex CQL types are not supported. I think this should come up next once the JSON ones are secured. It looks like we'll have to right our own avro codecs but will see if there is away of leveraging exiting ones (maybe adapt to the json ones)
* Json messages -> UDT types may not work well because the exiting if condition in the PulsarCodecProver routes all structs mapping to UDT to custom codec.