### PR TITLE
Add nested complex types e2e tests

### DIFF
--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/AvroTest.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/AvroTest.java
@@ -19,12 +19,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import com.datastax.oss.driver.internal.core.data.DefaultUdtValue;
 import com.datastax.oss.dsbulk.tests.ccm.CCMCluster;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -33,13 +36,42 @@ import org.awaitility.Awaitility;
 
 /** Use AVRO */
 public class AvroTest extends PulsarCCMTestBase {
+  private static final String MAPPING =
+          "a=key, b=value.field1, d=value.mapField, e=value.listField, f=value.pojoUdt, g=value.mapUdtFixedType, h=value.setField, "
+                  + "i=value.listOfMaps, j=value.setOfMaps, k=value.mapOfLists, l=value.mapOfSets, m=value.setOfLists, n=value.listOfSets";
   private final Map<String, String> map = ImmutableMap.of("k1", "v1", "k2", "v2");
   private final List<String> list = ImmutableList.of("l1", "l2");
-  private final MyUdt pojoUdt = new MyUdt(99, "random");
-  private final Map<String, String> mapUdt = ImmutableMap.of("intf", "36", "stringf", "udt text");
+  private final Set<String> set = ImmutableSet.of("s1", "s2");
+  private final List<Map<String, String>> listOfMaps = ImmutableList.of(map, map);
+  private final Set<Map<String, String>> setOfMaps = ImmutableSet.of(map, map);
+  private final Map<String, List<String>> mapOfLists = ImmutableMap.of("k1", list, "k2", list);
+  private final Map<String, Set<String>> mapOfSets = ImmutableMap.of("k1", set, "k2", set);
+  private final Set<List<String>> setOfLists = ImmutableSet.of(list);
+  private final List<Set<String>> listOfSets = ImmutableList.of(set, set);
+
+  private final MyUdt pojoUdt =
+      new MyUdt(
+          99,
+          "random",
+          ImmutableList.of("l1", "l2"),
+          ImmutableSet.of(3, 4),
+          ImmutableMap.of("k1", 7.0D, "k2", 9.0D));
+  /**
+   * AVRO schema with Pulsar doesn't work well with mixed value types on the map - the values will be of "org.apache.avro.generic.GenericData$Record"
+   * with the following limitations:
+   *  1. Using Map<String, Object> will result is "Unknown datum class: class
+   *    org.apache.avro.generic.GenericData$Record". because we try to convert those types to json via org.apache.avro.util.internal.JacksonUtils.toJson
+   *  2. Even without json conversion (which is our implementation detail) Also sending to Pulsar will result in a GenericObject with keys only and the value will be empty.
+   *
+   *  As a workaround for the test, the complex types are disabled by passing empty values. This use case will be covered with the JSON schema.
+   *
+   *  The alternative for the user is to use Pojo's with exact types to represent UDT's or switch to JSON schema.
+   */
+  private final Map<String, String> mapUdt =
+      ImmutableMap.of("intf", "36", "stringf", "udt text", "listf", "", "setf", "", "mapf", "");
 
   public AvroTest(CCMCluster ccm, CqlSession session) throws Exception {
-    super(ccm, session);
+    super(ccm, session, MAPPING);
   }
 
   @Override
@@ -54,7 +86,21 @@ public class AvroTest extends PulsarCCMTestBase {
       producer
           .newMessage()
           .key("838")
-          .value(new MyBean("value1", map, list, pojoUdt, mapUdt))
+          .value(
+              new MyBean(
+                  "value1",
+                  map,
+                  list,
+                  set,
+                  listOfMaps,
+                  setOfMaps,
+                  mapOfLists,
+                  mapOfSets,
+                  listOfSets,
+                  setOfLists,
+                  pojoUdt,
+                  null,
+                  mapUdt))
           .send();
     }
     try {
@@ -73,12 +119,46 @@ public class AvroTest extends PulsarCCMTestBase {
         assertEquals("value1", row.getString("b"));
         assertEquals(map, row.getMap("d", String.class, String.class));
         assertEquals(list, row.getList("e", String.class));
+        assertEquals(set, row.getSet("h", String.class));
+        GenericType<List<Map<String, String>>> listOfMapsType =
+            new GenericType<List<Map<String, String>>>() {};
+        List<Map<String, String>> mapsList = row.get("i", listOfMapsType);
+        assertEquals(listOfMaps, mapsList);
+        GenericType<Set<Map<String, String>>> setOfMapsType =
+            new GenericType<Set<Map<String, String>>>() {};
+        Set<Map<String, String>> mapsSet = row.get("j", setOfMapsType);
+        assertEquals(setOfMaps, mapsSet);
+
+        GenericType<Map<String, List<String>>> mapOfListsType =
+            new GenericType<Map<String, List<String>>>() {};
+        Map<String, List<String>> listsMap = row.get("k", mapOfListsType);
+        assertEquals(mapOfLists, listsMap);
+
+        GenericType<Map<String, Set<String>>> mapOfSetsType =
+            new GenericType<Map<String, Set<String>>>() {};
+        Map<String, Set<String>> setsMap = row.get("l", mapOfSetsType);
+        assertEquals(mapOfSets, setsMap);
+
+        GenericType<Set<List<String>>> setOfListsType = new GenericType<Set<List<String>>>() {};
+        Set<List<String>> listsSet = row.get("m", setOfListsType);
+        assertEquals(setOfLists, listsSet);
+        GenericType<List<Set<String>>> listOfSetsType = new GenericType<List<Set<String>>>() {};
+        List<Set<String>> setsList = row.get("n", listOfSetsType);
+        assertEquals(listOfSets, setsList);
+
         DefaultUdtValue value = (DefaultUdtValue) row.getUdtValue("f");
-        assertEquals(value.size(), 2);
+        assertEquals(value.size(), 5);
         assertEquals(pojoUdt.getIntf(), value.getInt("intf"));
         assertEquals(pojoUdt.getStringf(), value.getString("stringf"));
+        GenericType<List<String>> udtListType = new GenericType<List<String>>() {};
+        assertEquals(pojoUdt.getListf(), value.get("listf", udtListType));
+        GenericType<Set<Integer>> udtSetType = new GenericType<Set<Integer>>() {};
+        assertEquals(pojoUdt.getSetf(), value.get("setf", udtSetType));
+        GenericType<Map<String, Double>> udtMapType = new GenericType<Map<String, Double>>() {};
+        assertEquals(pojoUdt.getMapf(), value.get("mapf", udtMapType));
+
         value = (DefaultUdtValue) row.getUdtValue("g");
-        assertEquals(Integer.valueOf(mapUdt.get("intf")), value.getInt("intf"));
+        assertEquals(Integer.valueOf(mapUdt.get("intf").toString()), value.getInt("intf"));
         assertEquals(mapUdt.get("stringf"), value.getString("stringf"));
       }
       assertEquals(1, results.size());

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/JSONFromStringWithLegacyStringTaskTest.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/JSONFromStringWithLegacyStringTaskTest.java
@@ -19,12 +19,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import com.datastax.oss.driver.internal.core.data.DefaultUdtValue;
 import com.datastax.oss.dsbulk.tests.ccm.CCMCluster;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.ImmutableSet;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -34,7 +39,17 @@ import org.awaitility.Awaitility;
 public class JSONFromStringWithLegacyStringTaskTest extends PulsarCCMTestBase {
 
   private static final String MAPPING =
-      "a=key, b=value.field1, d=value.mapField, e=value.listField, f=value.udtField";
+          "a=key, b=value.field1, d=value.mapField, e=value.listField, f=value.udtField, h=value.setField, "
+                  + "i=value.listOfMaps, j=value.setOfMaps, k=value.mapOfLists, l=value.mapOfSets, m=value.setOfLists, n=value.listOfSets";
+
+  private static final String JSON = "{\"field1\":\"value1\",\"mapField\":{\"k1\":\"v1\",\"k2\":\"v2\"},\"listField\":[\"l1\",\"l2\"],\"setField\":[\"s1\",\"s2\"],"
+          +  "\"listOfMaps\":[{\"k1\":\"v1\",\"k2\":\"v2\"}, {\"k1\":\"v1\",\"k2\":\"v2\"}],"
+          +  "\"setOfMaps\":[{\"k1\":\"v1\",\"k2\":\"v2\"}],"
+          +  "\"mapOfLists\":{\"k1\":[\"l1\",\"l2\"],\"k2\":[\"l1\",\"l2\"]},"
+          +  "\"mapOfSets\":{\"k1\":[\"s1\",\"s2\"],\"k2\":[\"s1\",\"s2\"]},"
+          +  "\"setOfLists\":[[\"l1\",\"l2\"]],"
+          +  "\"listOfSets\":[[\"s1\",\"s2\"],[\"s1\",\"s2\"]],"
+          + "\"udtField\":{\"intf\":99,\"stringf\":\"random\",\"mapf\":{\"k1\":7.0,\"k2\":9.0},\"listf\":[\"l1\",\"l2\"],\"setf\":[3,4]}}";
 
   public JSONFromStringWithLegacyStringTaskTest(CCMCluster ccm, CqlSession session)
       throws Exception {
@@ -59,9 +74,7 @@ public class JSONFromStringWithLegacyStringTaskTest extends PulsarCCMTestBase {
       producer
           .newMessage()
           .key("838")
-          .value(
-              "{\"field1\":\"value1\",\"mapField\":{\"k1\":\"v1\",\"k2\":\"v2\"},\"listField\":[\"l1\",\"l2\"],\"udtField\":{\"intf\":99,\"stringf\":\"random\"}}")
-          .send();
+          .value(JSON).send();
     }
     try {
       Awaitility.waitAtMost(1, TimeUnit.MINUTES)
@@ -73,17 +86,50 @@ public class JSONFromStringWithLegacyStringTaskTest extends PulsarCCMTestBase {
               });
 
       List<Row> results = session.execute("SELECT * FROM table1").all();
+      List list = ImmutableList.of("l1", "l2");
+      Map map = ImmutableMap.of("k1", "v1", "k2", "v2");
+      Set set = ImmutableSet.of("s1", "s2");
       for (Row row : results) {
         log.info("ROW: " + row);
         assertEquals(838, row.getInt("a"));
         assertEquals("value1", row.getString("b"));
-        assertEquals(
-            ImmutableMap.of("k1", "v1", "k2", "v2"), row.getMap("d", String.class, String.class));
-        assertEquals(ImmutableList.of("l1", "l2"), row.getList("e", String.class));
+        assertEquals(map, row.getMap("d", String.class, String.class));
+        assertEquals(list, row.getList("e", String.class));
+        assertEquals(set, row.getSet("h", String.class));
+
+        GenericType<List<Map<String, String>>> listOfMapsType = new GenericType<List<Map<String, String>>>() {};
+        List<Map<String, String>> mapsList = row.get("i", listOfMapsType);
+        assertEquals(ImmutableList.of(map, map), mapsList);
+        GenericType<Set<Map<String, String>>> setOfMapsType = new GenericType<Set<Map<String, String>>>() {};
+        Set<Map<String, String>> mapsSet = row.get("j", setOfMapsType);
+        assertEquals(ImmutableSet.of(map), mapsSet);
+
+        GenericType<Map<String, List<String>>> mapOfListsType = new GenericType<Map<String, List<String>>>() {};
+        Map<String, List<String>> listsMap = row.get("k", mapOfListsType);
+        assertEquals(ImmutableMap.of("k1", list, "k2", list), listsMap);
+
+        GenericType<Map<String, Set<String>>> mapOfSetsType = new GenericType<Map<String, Set<String>>>() {};
+        Map<String, Set<String>> setsMap = row.get("l", mapOfSetsType);
+        assertEquals(ImmutableMap.of("k1", set, "k2", set), setsMap);
+
+        GenericType<Set<List<String>>> setOfListsType = new GenericType<Set<List<String>>>() {};
+        Set<List<String>> listsSet = row.get("m", setOfListsType);
+        assertEquals(ImmutableSet.of(list), listsSet);
+        GenericType<List<Set<String>>> listOfSetsType = new GenericType<List<Set<String>>>() {};
+        List<Set<String>> setsList = row.get("n", listOfSetsType);
+        assertEquals(ImmutableList.of(set, set), setsList);
+
         DefaultUdtValue value = (DefaultUdtValue) row.getUdtValue("f");
-        assertEquals(value.size(), 2);
+        assertEquals(value.size(), 5);
         assertEquals(99, value.getInt("intf"));
         assertEquals("random", value.getString("stringf"));
+
+        GenericType<List<String>> udtListType = new GenericType<List<String>>() {};
+        assertEquals(ImmutableList.of("l1", "l2"), value.get("listf", udtListType));
+        GenericType<Set<Integer>> udtSetType = new GenericType<Set<Integer>>() {};
+        assertEquals(ImmutableSet.of(3, 4), value.get("setf", udtSetType));
+        GenericType<Map<String, Double>> udtMapType = new GenericType<Map<String, Double>>() {};
+        assertEquals(ImmutableMap.of("k1", 7.0D,"k2",9.0D), value.get("mapf", udtMapType));
       }
       assertEquals(1, results.size());
     } finally {


### PR DESCRIPTION
Add the following new e2e tests #37:
1. Collection types: Set 
2. Nested types: list of maps, set of maps, maps of sets, maps of lists, list of sets, set of lists
3. UDT with complex types: UDT with map, set, list types

A note regarding UDT: If the user have mixed data types in the UDT, they have the following options when sending the message to pulsar:
1. Use Pojos -> this is fully supported with JSON and AVRO
2. Use` Map<String, Object>` -> This works with JSON but not AVRO - Pulsar messages with AVRO schema seem to have limited support with mixed value types. Running a simple Java app to produce/consume messages with `Map<String, Object>` causes the values to be lost at the consumer side. E.g.:
```
// Consumed generic object
{
   "body": "test", 
   "id": "99c61460-bd31-4625-b517-fd49b546b5e1", 
    "props": {"k1": {}, "k2": {}}, 
    "title": "my title"
}

// Pojo
public class MyPojo {
    ...
    public UUID id;
    public String title;
    public String body;
    public Map<String, Object> props;
}

// Avro schema for the map part
{"name":"props","type":["null",{"type":"map","values":{"type":"record","name":"Object","namespace":"java.lang","fields":[]}}],"default":null}
```

