### PR TITLE
Support Avro's collection of GenericData$Record data types

### DIFF
--- a/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/JsonConverter.java
+++ b/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/JsonConverter.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.sink.pulsar;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.GenericRecord;
+
+/** Convert an AVRO GenericRecord to a JsonNode. */
+public class JsonConverter {
+
+  private static final JsonNodeFactory jsonNodeFactory = JsonNodeFactory.withExactBigDecimals(true);
+
+  public static JsonNode toJson(GenericRecord genericRecord) {
+    if (genericRecord == null) {
+      return null;
+    }
+    ObjectNode objectNode = jsonNodeFactory.objectNode();
+    for (Schema.Field field : genericRecord.getSchema().getFields()) {
+      objectNode.set(field.name(), toJson(field.schema(), genericRecord.get(field.name())));
+    }
+    return objectNode;
+  }
+
+  public static JsonNode toJson(Schema schema, Object value) {
+    if (value == null) {
+      return jsonNodeFactory.nullNode();
+    }
+
+    if (AvroTypeUtil.shouldHandleCassandraCDCLogicalType(schema)) {
+      value = AvroTypeUtil.handleCassandraCDCLogicalType(value, schema);
+      if (value instanceof String) {
+        return jsonNodeFactory.textNode((String) value);
+      }
+    }
+
+    switch (schema.getType()) {
+      case INT:
+        return jsonNodeFactory.numberNode((Integer) value);
+      case LONG:
+        return jsonNodeFactory.numberNode((Long) value);
+      case DOUBLE:
+        return jsonNodeFactory.numberNode((Double) value);
+      case FLOAT:
+        return jsonNodeFactory.numberNode((Float) value);
+      case BOOLEAN:
+        return jsonNodeFactory.booleanNode((Boolean) value);
+      case BYTES:
+        return jsonNodeFactory.binaryNode((byte[]) value);
+      case FIXED:
+        return jsonNodeFactory.binaryNode(((GenericFixed) value).bytes());
+      case ENUM: // GenericEnumSymbol
+      case STRING:
+        return jsonNodeFactory.textNode(
+            value.toString()); // can be a String or org.apache.avro.util.Utf8
+      case ARRAY:
+        {
+          Schema elementSchema = schema.getElementType();
+          ArrayNode arrayNode = jsonNodeFactory.arrayNode();
+          Object[] iterable;
+          if (value instanceof GenericData.Array) {
+            iterable = ((GenericData.Array) value).toArray();
+          } else {
+            iterable = (Object[]) value;
+          }
+          for (Object elem : iterable) {
+            JsonNode fieldValue = toJson(elementSchema, elem);
+            arrayNode.add(fieldValue);
+          }
+          return arrayNode;
+        }
+      case MAP:
+        {
+          Map<Object, Object> map = (Map<Object, Object>) value;
+          ObjectNode objectNode = jsonNodeFactory.objectNode();
+          for (Map.Entry<Object, Object> entry : map.entrySet()) {
+            JsonNode jsonNode = toJson(schema.getValueType(), entry.getValue());
+            // can be a String or org.apache.avro.util.Utf8
+            final String entryKey = entry.getKey() == null ? null : entry.getKey().toString();
+            objectNode.set(entryKey, jsonNode);
+          }
+          return objectNode;
+        }
+      case RECORD:
+        return toJson((GenericRecord) value);
+      case UNION:
+        for (Schema s : schema.getTypes()) {
+          if (s.getType() == Schema.Type.NULL) {
+            continue;
+          }
+          return toJson(s, value);
+        }
+      default:
+        return jsonNodeFactory.nullNode();
+    }
+  }
+}

--- a/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/PulsarSchema.java
+++ b/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/PulsarSchema.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.avro.util.internal.JacksonUtils;
+import org.apache.avro.Schema;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.slf4j.Logger;
@@ -128,7 +128,12 @@ public class PulsarSchema implements AbstractSchema {
         value = AvroTypeUtil.handleCassandraCDCLogicalType(template, f.getName(), value);
       } else if (AvroTypeUtil.shouldWrapAvroType(template, value)) {
         // Wrap avro container types with a generic record to utilize the json codecs
-        value = new AvroContainerTypeRecord(JacksonUtils.toJsonNode(value));
+        Schema schema =
+            ((org.apache.avro.generic.GenericRecord) template.getNativeObject())
+                .getSchema()
+                .getField(f.getName())
+                .schema();
+        value = new AvroContainerTypeRecord(JsonConverter.toJson(schema, value));
       }
       // in case of null value we are going to use
       // a dummy (string) type

--- a/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/PulsarStruct.java
+++ b/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/PulsarStruct.java
@@ -19,7 +19,6 @@ import com.datastax.oss.common.sink.AbstractSchema;
 import com.datastax.oss.common.sink.AbstractStruct;
 import com.datastax.oss.common.sink.util.SinkUtil;
 import java.util.Optional;
-import org.apache.avro.util.internal.JacksonUtils;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.functions.api.Record;
@@ -93,7 +92,12 @@ public class PulsarStruct implements AbstractStruct {
     if (AvroTypeUtil.shouldHandleCassandraCDCLogicalType(record, fieldName)) {
       field = AvroTypeUtil.handleCassandraCDCLogicalType(record, fieldName, field);
     } else if (AvroTypeUtil.shouldWrapAvroType(record, field)) {
-      field = new AvroContainerTypeRecord(JacksonUtils.toJsonNode(field));
+      org.apache.avro.Schema schema =
+          ((org.apache.avro.generic.GenericRecord) record.getNativeObject())
+              .getSchema()
+              .getField(fieldName)
+              .schema();
+      field = new AvroContainerTypeRecord(JsonConverter.toJson(schema, field));
     }
 
     return wrap(this, fieldName, field, schemaRegistry);

--- a/pulsar-impl/src/test/java/com/datastax/oss/sink/pulsar/JsonConverterTests.java
+++ b/pulsar-impl/src/test/java/com/datastax/oss/sink/pulsar/JsonConverterTests.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.sink.pulsar;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+import java.util.UUID;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.junit.Test;
+
+public class JsonConverterTests {
+
+  @Test
+  public void testAvroToJson() throws IOException {
+    Schema avroArraySchema = SchemaBuilder.array().items(SchemaBuilder.builder().stringType());
+    Schema schema =
+        SchemaBuilder.record("record")
+            .fields()
+            .name("n")
+            .type()
+            .longType()
+            .longDefault(10)
+            .name("l")
+            .type()
+            .longType()
+            .longDefault(10)
+            .name("i")
+            .type()
+            .intType()
+            .intDefault(10)
+            .name("b")
+            .type()
+            .booleanType()
+            .booleanDefault(true)
+            .name("bb")
+            .type()
+            .bytesType()
+            .bytesDefault("10")
+            .name("d")
+            .type()
+            .doubleType()
+            .doubleDefault(10.0)
+            .name("f")
+            .type()
+            .floatType()
+            .floatDefault(10.0f)
+            .name("s")
+            .type()
+            .stringType()
+            .stringDefault("titi")
+            .name("fi")
+            .type()
+            .fixed("fi")
+            .size(3)
+            .fixedDefault(new byte[] {1, 2, 3})
+            .name("en")
+            .type()
+            .enumeration("en")
+            .symbols("a", "b", "c")
+            .enumDefault("b")
+            .name("array")
+            .type()
+            .optional()
+            .array()
+            .items(SchemaBuilder.builder().stringType())
+            .name("arrayavro")
+            .type()
+            .optional()
+            .array()
+            .items(SchemaBuilder.builder().stringType())
+            .name("map")
+            .type()
+            .optional()
+            .map()
+            .values(SchemaBuilder.builder().intType())
+            .name("maputf8")
+            .type()
+            .optional()
+            .map()
+            .values(SchemaBuilder.builder().intType())
+            .endRecord();
+    GenericRecord genericRecord = new GenericData.Record(schema);
+    genericRecord.put("n", null);
+    genericRecord.put("l", 1L);
+    genericRecord.put("i", 1);
+    genericRecord.put("b", true);
+    genericRecord.put("bb", "10".getBytes(StandardCharsets.UTF_8));
+    genericRecord.put("d", 10.0);
+    genericRecord.put("f", 10.0f);
+    genericRecord.put("s", "toto");
+    genericRecord.put(
+        "fi",
+        GenericData.get()
+            .createFixed(null, new byte[] {'a', 'b', 'c'}, schema.getField("fi").schema()));
+    genericRecord.put("en", GenericData.get().createEnum("b", schema.getField("en").schema()));
+    genericRecord.put("array", new String[] {"toto"});
+    genericRecord.put("arrayavro", new GenericData.Array<>(avroArraySchema, Arrays.asList("toto")));
+    genericRecord.put("map", ImmutableMap.of("a", 10));
+    genericRecord.put("maputf8", ImmutableMap.of(new org.apache.avro.util.Utf8("a"), 10));
+    JsonNode jsonNode = JsonConverter.toJson(genericRecord);
+    assertEquals(jsonNode.get("n"), NullNode.getInstance());
+    assertEquals(jsonNode.get("l").asLong(), 1L);
+    assertEquals(jsonNode.get("i").asInt(), 1);
+    assertEquals(jsonNode.get("b").asBoolean(), true);
+    assertArrayEquals(jsonNode.get("bb").binaryValue(), "10".getBytes(StandardCharsets.UTF_8));
+    assertArrayEquals(jsonNode.get("fi").binaryValue(), "abc".getBytes(StandardCharsets.UTF_8));
+    assertEquals(jsonNode.get("en").textValue(), "b");
+    assertEquals(jsonNode.get("d").asDouble(), 10.0, 0);
+    assertEquals(jsonNode.get("f").numberValue(), 10.0f);
+    assertEquals(jsonNode.get("s").asText(), "toto");
+    assertTrue(jsonNode.get("array").isArray());
+    assertEquals(jsonNode.get("array").iterator().next().asText(), "toto");
+    assertTrue(jsonNode.get("arrayavro").isArray());
+    assertEquals(jsonNode.get("arrayavro").iterator().next().asText(), "toto");
+    assertTrue(jsonNode.get("map").isObject());
+    assertEquals(jsonNode.get("map").elements().next().asText(), "10");
+    assertEquals(jsonNode.get("map").get("a").numberValue(), 10);
+    assertTrue(jsonNode.get("maputf8").isObject());
+    assertEquals(jsonNode.get("maputf8").elements().next().asText(), "10");
+    assertEquals(jsonNode.get("maputf8").get("a").numberValue(), 10);
+  }
+
+  @Test
+  public void testLogicalTypesToJson() throws IOException {
+    Schema dateType = LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT));
+    Schema timestampMillisType =
+        LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG));
+    Schema timestampMicrosType =
+        LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
+    Schema timeMillisType = LogicalTypes.timeMillis().addToSchema(Schema.create(Schema.Type.INT));
+    Schema timeMicrosType = LogicalTypes.timeMicros().addToSchema(Schema.create(Schema.Type.LONG));
+    Schema uuidType = LogicalTypes.uuid().addToSchema(Schema.create(Schema.Type.STRING));
+    Schema schema =
+        SchemaBuilder.record("record")
+            .fields()
+            .name("mydate")
+            .type(dateType)
+            .noDefault()
+            .name("tsmillis")
+            .type(timestampMillisType)
+            .noDefault()
+            .name("tsmicros")
+            .type(timestampMicrosType)
+            .noDefault()
+            .name("timemillis")
+            .type(timeMillisType)
+            .noDefault()
+            .name("timemicros")
+            .type(timeMicrosType)
+            .noDefault()
+            .name("myuuid")
+            .type(uuidType)
+            .noDefault()
+            .endRecord();
+
+    final long MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
+    UUID myUuid = UUID.randomUUID();
+    Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("Europe/Copenhagen"));
+    GenericRecord genericRecord = new GenericData.Record(schema);
+    genericRecord.put("mydate", (int) calendar.toInstant().getEpochSecond());
+    genericRecord.put("tsmillis", calendar.getTimeInMillis());
+    genericRecord.put("tsmicros", calendar.getTimeInMillis() * 1000);
+    genericRecord.put("timemillis", (int) (calendar.getTimeInMillis() % MILLIS_PER_DAY));
+    genericRecord.put("timemicros", (calendar.getTimeInMillis() % MILLIS_PER_DAY) * 1000);
+    genericRecord.put("myuuid", myUuid.toString());
+
+    GenericRecord genericRecord2 = deserialize(serialize(genericRecord, schema), schema);
+    JsonNode jsonNode = JsonConverter.toJson(genericRecord2);
+    assertEquals(jsonNode.get("mydate").asInt(), calendar.toInstant().getEpochSecond());
+    assertEquals(jsonNode.get("tsmillis").asInt(), (int) calendar.getTimeInMillis());
+    assertEquals(jsonNode.get("tsmicros").asLong(), calendar.getTimeInMillis() * 1000);
+    assertEquals(
+        jsonNode.get("timemillis").asInt(), (int) (calendar.getTimeInMillis() % MILLIS_PER_DAY));
+    assertEquals(
+        jsonNode.get("timemicros").asLong(), (calendar.getTimeInMillis() % MILLIS_PER_DAY) * 1000);
+    assertEquals(UUID.fromString(jsonNode.get("myuuid").asText()), myUuid);
+  }
+
+  public static byte[] serialize(GenericRecord record, Schema schema) throws IOException {
+    SpecificDatumWriter<GenericRecord> datumWriter = new SpecificDatumWriter<>(schema);
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    BinaryEncoder binaryEncoder = new EncoderFactory().binaryEncoder(byteArrayOutputStream, null);
+    datumWriter.write(record, binaryEncoder);
+    binaryEncoder.flush();
+    return byteArrayOutputStream.toByteArray();
+  }
+
+  public static GenericRecord deserialize(byte[] recordBytes, Schema schema) throws IOException {
+    DatumReader<GenericRecord> datumReader = new SpecificDatumReader<>(schema);
+    ByteArrayInputStream stream = new ByteArrayInputStream(recordBytes);
+    BinaryDecoder binaryDecoder = new DecoderFactory().binaryDecoder(stream, null);
+    return datumReader.read(null, binaryDecoder);
+  }
+}

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/AvroLogicalTypesTest.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/AvroLogicalTypesTest.java
@@ -135,14 +135,18 @@ public class AvroLogicalTypesTest extends PulsarCCMTestBase {
 
     List<org.apache.avro.Schema.Field> udtFields = new ArrayList<>();
     udtFields.add(createDecimalField("decimalf"));
-    udtFields.add(createDurationsField("durationf"));
+    if (hasDurationType) {
+      udtFields.add(createDurationsField("durationf"));
+    }
     udtFields.add(createUUIDField("uuidf"));
     udtFields.add(createVarintField("varintf"));
     org.apache.avro.Schema udtSchema =
         org.apache.avro.Schema.createRecord("udt", "", "ns1", false, udtFields);
     org.apache.avro.generic.GenericRecord udtRecord = new GenericData.Record(udtSchema);
     udtRecord.put("decimalf", createDecimalRecord(decimal));
-    udtRecord.put("durationf", createDurationRecord(duration));
+    if (hasDurationType) {
+      udtRecord.put("durationf", createDurationRecord(duration));
+    }
     udtRecord.put("uuidf", uuid.toString());
     udtRecord.put("varintf", ByteBuffer.wrap(bigInteger.toByteArray()));
 

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/PulsarCCMTestBase.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/PulsarCCMTestBase.java
@@ -50,7 +50,7 @@ abstract class PulsarCCMTestBase {
 
   private static final String DEFAULT_MAPPING =
       "a=key, b=value.field1, d=value.mapField, e=value.listField, f=value.pojoUdt, g=value.mapUdt, h=value.setField, "
-          + "i=value.listOfMaps, j=value.setOfMaps, k=value.mapOfLists, l=value.mapOfSets, m=value.setOfLists, n=value.listOfSets";
+          + "i=value.listOfMaps, j=value.setOfMaps, k=value.mapOfLists, l=value.mapOfSets, m=value.setOfLists, n=value.listOfSets, s=value.listOfUdt";
 
   @SuppressWarnings("unused")
   PulsarCCMTestBase(CCMCluster ccm, CqlSession session) throws Exception {
@@ -74,6 +74,14 @@ abstract class PulsarCCMTestBase {
                 "CREATE TYPE udt (intf int, stringf text, listf frozen<list<text>>, setf frozen<set<int>>, mapf frozen<map<text, double>>)")
             .setTimeout(Duration.ofSeconds(10))
             .build());
+    // create UDT with logical types
+    session.execute(
+        SimpleStatement.builder(
+                "CREATE TYPE udtLogicalTypes (decimalf decimal"
+                    + (this.hasDurationType ? ", durationf duration" : "")
+                    + ", uuidf uuid, varintf varint)")
+            .setTimeout(Duration.ofSeconds(10))
+            .build());
     session.execute(
         SimpleStatement.builder(
                 "CREATE TABLE IF NOT EXISTS table1 ("
@@ -95,7 +103,10 @@ abstract class PulsarCCMTestBase {
                     + "o decimal, "
                     + (this.hasDurationType ? "p duration, " : "")
                     + "q uuid, "
-                    + "r varint)")
+                    + "r varint,"
+                    + "s list<frozen<udt>>,"
+                    + "t udtLogicalTypes,"
+                    + "u list<frozen<udtLogicalTypes>>)")
             .build());
 
     connectorProperties = new HashMap<>();
@@ -218,8 +229,8 @@ abstract class PulsarCCMTestBase {
     private Set<List<String>> setOfLists;
     private MyUdt pojoUdt;
     private Map<String, Object> mapUdt;
-
     private Map<String, String> mapUdtFixedType;
+    private List<MyUdt> listOfUdt;
 
     public MyBean(String field1) {
       this.field1 = field1;
@@ -243,7 +254,8 @@ abstract class PulsarCCMTestBase {
         Set<List<String>> setOfLists,
         MyUdt pojoUdt,
         Map<String, Object> mapUdt,
-        Map<String, String> mapUdtFixedType) {
+        Map<String, String> mapUdtFixedType,
+        List<MyUdt> listOfUdt) {
       this(stringField, Instant.now().toEpochMilli());
       this.mapField = mapField;
       this.listField = listField;
@@ -257,6 +269,7 @@ abstract class PulsarCCMTestBase {
       this.pojoUdt = pojoUdt;
       this.mapUdt = mapUdt;
       this.mapUdtFixedType = mapUdtFixedType;
+      this.listOfUdt = listOfUdt;
     }
 
     public String getField1() {
@@ -369,6 +382,14 @@ abstract class PulsarCCMTestBase {
 
     public void setMapUdtFixedType(Map<String, String> mapUdtFixedType) {
       this.mapUdtFixedType = mapUdtFixedType;
+    }
+
+    public List<MyUdt> getListOfUdt() {
+      return listOfUdt;
+    }
+
+    public void setListOfUdt(List<MyUdt> listOfUdt) {
+      this.listOfUdt = listOfUdt;
     }
   }
 }

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/PulsarCCMTestBase.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/PulsarCCMTestBase.java
@@ -90,8 +90,8 @@ abstract class PulsarCCMTestBase {
                     + "c TIMESTAMP, "
                     + "d map<text,text>, "
                     + "e list<text>, "
-                    + "f FROZEN<udt>, "
-                    + "g FROZEN<udt>, " // Non-frozen User-Defined types are not supported in
+                    + "f frozen<udt>, "
+                    + "g frozen<udt>, " // Non-frozen User-Defined types are not supported in
                     // Cassandra 3.0
                     + "h set<text>, "
                     + "i list<frozen<map<text,text>>>, "
@@ -105,7 +105,7 @@ abstract class PulsarCCMTestBase {
                     + "q uuid, "
                     + "r varint,"
                     + "s list<frozen<udt>>,"
-                    + "t udtLogicalTypes,"
+                    + "t frozen<udtLogicalTypes>,"
                     + "u list<frozen<udtLogicalTypes>>)")
             .build());
 


### PR DESCRIPTION
This patch adds support for:
* Avro collections of generic records -> C* collections of UDT (see #41 )
* Upstream CDC UDT of logical types -> C* UDT of logical types
* Upstream CDC collections of UDT of logical types -> C* collections of UDT of logical types

i.e. the following column types in sink:
```
list<frozen<udt>>, udtLogicalTypes, list<frozen<udtLogicalTypes>>
```
where udtLogicalTypes is:
```
CREATE TYPE udtLogicalTypes (decimalf decimal, durationf duration, uuidf uuid, varintf varint);
```

Implementation wise, I removed the dependency on [JacksonUtils.toJson ](https://github.com/apache/avro/blob/42822886c28ea74a744abb7e7a80a942c540faa5/lang/java/avro/src/main/java/org/apache/avro/util/internal/JacksonUtils.java#L61) and ported the JsonConverter code from the ElasticseachSink - adapted with the upstream CDC logical types. 
  