### PR TITLE
Upgrade jackson to 2.12.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <lz4.version>1.6.0</lz4.version>
     <snappy.version>1.1.7.2</snappy.version>
     <jackson.version>2.12.6</jackson.version>
-    <jackson-databind.version>2.12.6.1</jackson-databind.version>
+    <jackson-databind.version>2.12.7.1</jackson-databind.version>
     <logback.version>1.2.9</logback.version>
     <jnr.version>3.1.15</jnr.version>
     <avro.version>1.10.2</avro.version>


### PR DESCRIPTION
### Motivation

`jackson-databind`  2.12.6.1 is vulnerable to [CVE-2022-42003](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-42003)

### Modifications

* Upgrade to 2.12.7.1

there's no strong reason to bump to 2.13.x so it's more conservative to remain on 2.12.x

