### PR TITLE
Upgrade Netty and Jackson to get rid of CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,7 @@
     <metrics.version>4.0.2</metrics.version>
     <lz4.version>1.6.0</lz4.version>
     <snappy.version>1.1.7.2</snappy.version>
-    <jackson.version>2.12.6</jackson.version>
-    <jackson-databind.version>2.12.7.1</jackson-databind.version>
+    <jackson.version>2.13.4.20221013</jackson.version>
     <logback.version>1.2.9</logback.version>
     <jnr.version>3.1.15</jnr.version>
     <avro.version>1.10.2</avro.version>
@@ -126,19 +125,11 @@
         <version>${snappy.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
         <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson-databind.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -192,7 +183,24 @@
       </dependency>
       <dependency>
         <groupId>org.apache.pulsar</groupId>
-        <artifactId>pulsar-io-common</artifactId>
+        <artifactId>pulsar-io-core</artifactId>
+        <version>${pulsar.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.pulsar</groupId>
+        <artifactId>pulsar-functions-api</artifactId>
+        <version>${pulsar.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.pulsar</groupId>
+        <artifactId>pulsar-client-api</artifactId>
+        <version>${pulsar.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.pulsar</groupId>
+        <artifactId>pulsar-common</artifactId>
         <version>${pulsar.version}</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,7 @@
     <max.ccm.clusters>2</max.ccm.clusters>
     <commons-exec.version>1.3</commons-exec.version>
     <awaitility.version>4.0.1</awaitility.version>
-    <netty.version>4.1.72.Final</netty.version>
-    <netty.tcnative.version>2.0.46.Final</netty.tcnative.version>
+    <netty.version>4.1.86.Final</netty.version>
     <metrics.version>4.0.2</metrics.version>
     <lz4.version>1.6.0</lz4.version>
     <snappy.version>1.1.7.2</snappy.version>
@@ -96,13 +95,10 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>${netty.tcnative.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-common</artifactId>
+        <artifactId>netty-bom</artifactId>
         <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,16 +106,6 @@
         <version>${netty.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-handler</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-haproxy</artifactId>
-        <version>${netty.version}</version>
-      </dependency>
-      <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
         <version>${metrics.version}</version>

--- a/pulsar-dist/pom.xml
+++ b/pulsar-dist/pom.xml
@@ -55,7 +55,7 @@
       <plugin>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-maven-plugin</artifactId>
-        <version>1.3.2</version>
+        <version>1.3.4</version>
         <extensions>true</extensions>
         <configuration>
           <finalName>cassandra-enhanced-pulsar-sink-${project.version}</finalName>

--- a/pulsar-impl/pom.xml
+++ b/pulsar-impl/pom.xml
@@ -35,22 +35,6 @@
       <artifactId>messaging-connectors-commons-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-common</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-handler</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-haproxy</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-io-common</artifactId>
       <scope>provided</scope>

--- a/pulsar-impl/pom.xml
+++ b/pulsar-impl/pom.xml
@@ -33,6 +33,7 @@
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>messaging-connectors-commons-core</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.pulsar</groupId>

--- a/pulsar-impl/pom.xml
+++ b/pulsar-impl/pom.xml
@@ -36,17 +36,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pulsar</groupId>
-      <artifactId>pulsar-io-common</artifactId>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-client-original</artifactId>
       <scope>test</scope>
     </dependency>
@@ -121,6 +110,31 @@
       <version>${avro.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-io-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-functions-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-client-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-common</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -181,7 +195,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
                 </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <relocations>
                 <relocation>

--- a/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/AvroContainerTypeRecord.java
+++ b/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/AvroContainerTypeRecord.java
@@ -16,8 +16,8 @@
 package com.datastax.oss.sink.pulsar;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -106,10 +106,10 @@ public class AvroContainerTypeRecord implements GenericRecord {
 
   private List<Field> populateFields(JsonNode node) {
     AtomicInteger idx = new AtomicInteger(0);
-    return (List)
-        Lists.newArrayList(node.fieldNames())
-            .stream()
-            .map((f) -> new Field(f, idx.getAndIncrement()))
-            .collect(Collectors.toList());
+    List<String> list = new ArrayList<>();
+    node.fieldNames().forEachRemaining(list::add);
+    return list.stream()
+        .map((f) -> new Field(f, idx.getAndIncrement()))
+        .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
* Import netty's bom and upgrade to 4.1.86
* Import Jackson's bom and upgrade to 2.13.4
* Fix runtime dependencies for the nar. Some of them were provided but Pulsar doesn't ensure to be there at runtime (pulsar-common)