### PR TITLE
Upgrade kafka clients to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <jnr.version>3.1.15</jnr.version>
     <avro.version>1.10.2</avro.version>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
+    <kafka-clients.version>3.4.0</kafka-clients.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -77,6 +78,12 @@
         <groupId>com.datastax.oss</groupId>
         <artifactId>messaging-connectors-commons-core</artifactId>
         <version>${messaging.connectors.commons.version}</version>
+      </dependency>
+      <dependency>
+        <!-- For messaging-connectors-commons-core. it only uses Kafka Config utilities -->
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>${kafka-clients.version}</version>
       </dependency>
       <dependency>
         <groupId>org.json</groupId>


### PR DESCRIPTION
`messaging-connectors-commons` depends on `kafka-clients` for the config. 2.4.0 contains CVE-2023-25194.
Upgrade to 3.4.0