### PR TITLE
[feature] Map native Avro logical type that are generated by the an upstream CDC source

### DIFF
--- a/pulsar-impl/pom.xml
+++ b/pulsar-impl/pom.xml
@@ -196,7 +196,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
                 </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <relocations>
                 <relocation>

--- a/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/CqlLogicalTypes.java
+++ b/pulsar-impl/src/main/java/com/datastax/oss/sink/pulsar/CqlLogicalTypes.java
@@ -19,8 +19,12 @@ import com.datastax.oss.driver.api.core.data.CqlDuration;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import org.apache.avro.Conversion;
 import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 
@@ -28,6 +32,10 @@ public class CqlLogicalTypes {
   public static final String CQL_VARINT = "cql_varint";
   public static final String CQL_DECIMAL = "cql_decimal";
   public static final String CQL_DURATION = "cql_duration";
+
+  public static final String DATE = LogicalTypes.date().getName();
+  public static final String TIME_MICROS = LogicalTypes.timeMicros().getName();
+  public static final String TIMESTAMP_MILLIS = LogicalTypes.timestampMillis().getName();
 
   public static class CqlDurationConversion extends Conversion<CqlDuration> {
     @Override
@@ -86,6 +94,57 @@ public class CqlLogicalTypes {
       byte[] arr = new byte[value.remaining()];
       value.duplicate().get(arr);
       return new BigInteger(arr);
+    }
+  }
+
+  public static class DateConversion extends Conversion<LocalDate> {
+    @Override
+    public Class<LocalDate> getConvertedType() {
+      return LocalDate.class;
+    }
+
+    @Override
+    public String getLogicalTypeName() {
+      return DATE;
+    }
+
+    @Override
+    public LocalDate fromInt(Integer value, Schema schema, LogicalType type) {
+      return LocalDate.ofEpochDay(value);
+    }
+  }
+
+  public static class TimeConversion extends Conversion<LocalTime> {
+    @Override
+    public Class<LocalTime> getConvertedType() {
+      return LocalTime.class;
+    }
+
+    @Override
+    public String getLogicalTypeName() {
+      return TIME_MICROS;
+    }
+
+    @Override
+    public LocalTime fromLong(Long value, Schema schema, LogicalType type) {
+      return LocalTime.ofNanoOfDay(value * 1000);
+    }
+  }
+
+  public static class TimestampConversion extends Conversion<Instant> {
+    @Override
+    public Class<Instant> getConvertedType() {
+      return Instant.class;
+    }
+
+    @Override
+    public String getLogicalTypeName() {
+      return TIMESTAMP_MILLIS;
+    }
+
+    @Override
+    public Instant fromLong(Long value, Schema schema, LogicalType type) {
+      return Instant.ofEpochMilli(value);
     }
   }
 

--- a/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/PulsarCCMTestBase.java
+++ b/tests/src/test/java/com/datastax/oss/pulsar/sink/simulacron/PulsarCCMTestBase.java
@@ -79,7 +79,7 @@ abstract class PulsarCCMTestBase {
         SimpleStatement.builder(
                 "CREATE TYPE udtLogicalTypes (decimalf decimal"
                     + (this.hasDurationType ? ", durationf duration" : "")
-                    + ", uuidf uuid, varintf varint)")
+                    + ", uuidf uuid, varintf varint, datef date, timef time, timestampf timestamp)")
             .setTimeout(Duration.ofSeconds(10))
             .build());
     session.execute(
@@ -106,7 +106,10 @@ abstract class PulsarCCMTestBase {
                     + "r varint,"
                     + "s list<frozen<udt>>,"
                     + "t frozen<udtLogicalTypes>,"
-                    + "u list<frozen<udtLogicalTypes>>)")
+                    + "u list<frozen<udtLogicalTypes>>,"
+                    + "v date,"
+                    + "w time,"
+                    + "x timestamp)")
             .build());
 
     connectorProperties = new HashMap<>();


### PR DESCRIPTION
This patch adds support for the native Avro logical type that are generated by the an upstream CDC source. Those are namely `[date, time-micros, timstamp-millis]` as can be found [here](https://github.com/datastax/cdc-apache-cassandra/blob/cd64bdd03af7a608687b6c54aa614021c62d8027/commons/src/main/java/com/datastax/oss/cdc/CqlLogicalTypes.java#L29-L31)

The new types will be gated behind the `decodeCDCDataTypes` that was introduced in [this](https://github.com/datastax/pulsar-sink/pull/42) PR. All other CDC logical types are already supported.