### PR TITLE
deps: Update dependency to fix CVE-2023-5072 & CVE-2023-6378

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   </modules>
   <properties>
     <messaging.connectors.commons.version>1.0.15</messaging.connectors.commons.version>
-    <org.json.version>20230227</org.json.version>
+    <org.json.version>20231013</org.json.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
@@ -48,7 +48,7 @@
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <pulsar.version>2.8.2</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <logback.version>1.2.3</logback.version>
+    <logback.version>1.2.13</logback.version>
     <junit.version>5.4.1</junit.version>
     <assertj.version>3.14.0</assertj.version>
     <mockito.version>2.18.3</mockito.version>
@@ -66,7 +66,6 @@
     <lz4.version>1.6.0</lz4.version>
     <snappy.version>1.1.7.2</snappy.version>
     <jackson.version>2.13.4.20221013</jackson.version>
-    <logback.version>1.2.9</logback.version>
     <jnr.version>3.1.15</jnr.version>
     <avro.version>1.10.2</avro.version>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>


### PR DESCRIPTION
### Motivation
To Avoid the following Vulnerabilities 

- Json:  CVE-2023-5072
- Logback-core & Logback-classic: CVE-2023-6378 

### Modifications
Upgraded Following versions - 

- Json : 20230227 -> 20231013
- Logback : 1.2.9 -> 1.2.13