### PR TITLE
Upgrade Avro to 1.11.4 to address CVE-2024-47561

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <snappy.version>1.1.7.2</snappy.version>
     <jackson.version>2.13.4.20221013</jackson.version>
     <jnr.version>3.1.15</jnr.version>
-    <avro.version>1.10.2</avro.version>
+    <avro.version>1.11.4</avro.version>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <kafka-clients.version>3.4.0</kafka-clients.version>
   </properties>


### PR DESCRIPTION
### Motivation

Avro 1.11.3 contains critical 9.3/10 level RCE vulnerability in Avro Java SDK <1.11.4, [CVE-2024-47561](https://github.com/advisories/GHSA-r7pg-v2c8-mfg3)>