### PR TITLE
deps: Update dependency to fix CVE-2024-36114 & CVE-2024-53990

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,8 @@
     <avro.version>1.11.4</avro.version>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <kafka-clients.version>3.4.0</kafka-clients.version>
+    <asynchttpclient.version>2.12.4</asynchttpclient.version>
+    <aircompressor.version>0.27</aircompressor.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -264,6 +266,16 @@
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-client-admin-original</artifactId>
         <version>${pulsar.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.airlift</groupId>
+        <artifactId>aircompressor</artifactId>
+        <version>${aircompressor.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.asynchttpclient</groupId>
+        <artifactId>async-http-client</artifactId>
+        <version>${asynchttpclient.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION

asynchttpclient 2.12.1 contains CVE-2024-53990 vulnerability and its fixed in 2.12.4.
aircompressor 0.21 contains CVE-2024-36114 vulnerability and its fixed in 0.27